### PR TITLE
Add the ability to run the LLM workflow from the browser

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,22 @@
       <div class="row mt-3 mb-5" id="imagePreviewContainer">
         <!-- Images will be added here dynamically -->
       </div>
+
+      <!-- Generate Caption Button -->
+      <div class="row mt-3 mb-5 text-center">
+        <div class="col-12">
+          <button id="generateCaptionButton" class="btn btn-success btn-lg">
+            Generate Caption
+          </button>
+        </div>
+      </div>
+
+      <!-- Caption Display -->
+      <div class="row mt-3 mb-5 text-center">
+        <div class="col-12">
+          <div id="captionDisplay"></div>
+        </div>
+      </div>
     </div>
 
   </body>

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -59,3 +59,5 @@ export function generatePhotoAttachments(photos: Photo[]): ChatCompletionMessage
     ])).flat()
   })
 }
+
+export { Providers, Models, SystemMessage, generatePhotoAttachments }


### PR DESCRIPTION
Add the ability to run the LLM workflow from the browser.

* **index.html**
  - Add a "Generate Caption" button below the image thumbnails display.
  - Add a `div` element with an `id` attribute to display the generated caption.

* **script.ts**
  - Add an event listener for the "Generate Caption" button click.
  - Implement a function to handle the button click, turning images into prompts.
  - Call the LLM provider to generate a caption and insert it as a `div` below the "Generate Caption" button.
  - Hardcode a default model and provider.

* **llm.ts**
  - Export the `Providers` and `Models` objects for use in the browser.
  - Export the `SystemMessage` object for use in the browser.
  - Export the `generatePhotoAttachments` function for use in the browser.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/championswimmer/genai-photo-captioner/pull/1?shareId=6465b667-cdf0-43c3-8a0a-56c5ae65af77).